### PR TITLE
Redefine 'abnormal aging' to remove dependency on GO:0007568.

### DIFF
--- a/src/ontology/dpo-edit.owl
+++ b/src/ontology/dpo-edit.owl
@@ -986,7 +986,7 @@ SubClassOf(obo:FBcv_0000383 obo:FBcv_0001347)
 
 # Class: obo:FBcv_0000384 (abnormal aging)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:PO_curators") obo:IAO_0000115 obo:FBcv_0000384 "Phenotype that is any abnormality in aging (GO:0007568). 'aging' is defined as: '$sub_GO:0007568'")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:PO_curators") obo:IAO_0000115 obo:FBcv_0000384 "Phenotype that is any abnormality in aging.")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:FBcv_0000384 "aging defective")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:FBcv_0000384 "phenotypic_class")
 AnnotationAssertion(oboInOwl:id obo:FBcv_0000384 "FBcv:0000384")
@@ -2011,22 +2011,22 @@ SubClassOf(obo:FBcv_0000734 obo:FBcv_0000698)
 
 # Class: obo:FBcv_0000791 (decreased speed of aging)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBC:DOC") obo:IAO_0000115 obo:FBcv_0000791 "A phenotype in which the aging process (GO:0007568) is slower than in wild-type.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBC:DOC") obo:IAO_0000115 obo:FBcv_0000791 "A phenotype in which the aging process is slower than in wild-type.")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:FBcv_0000791 "reduced speed of aging")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:FBcv_0000791 "phenotypic_class")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:FBcv_0000791 "delayed aging")
 AnnotationAssertion(oboInOwl:id obo:FBcv_0000791 "FBcv:0000791")
 AnnotationAssertion(rdfs:label obo:FBcv_0000791 "decreased speed of aging")
-SubClassOf(obo:FBcv_0000791 obo:FBcv_0001347)
+SubClassOf(obo:FBcv_0000791 obo:FBcv_0000384)
 
 # Class: obo:FBcv_0000792 (increased speed of aging)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBC:DOC") obo:IAO_0000115 obo:FBcv_0000792 "A phenotype in which the aging process (GO:0007568) is accelerated compared to wild-type.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBC:DOC") obo:IAO_0000115 obo:FBcv_0000792 "A phenotype in which the aging process is accelerated compared to wild-type.")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:FBcv_0000792 "phenotypic_class")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:FBcv_0000792 "premature aging")
 AnnotationAssertion(oboInOwl:id obo:FBcv_0000792 "FBcv:0000792")
 AnnotationAssertion(rdfs:label obo:FBcv_0000792 "increased speed of aging")
-SubClassOf(obo:FBcv_0000792 obo:FBcv_0001347)
+SubClassOf(obo:FBcv_0000792 obo:FBcv_0000384)
 
 # Class: obo:FBcv_0001324 (obsolete endocytosis defective)
 


### PR DESCRIPTION
Since [aging](http://purl.obolibrary.org/obo/GO_0007568) is now obsolete in GO, and does not have a proposed replacement AFAIK, we redefine our own [abnormal aging](http://purl.obolibrary.org/obo/FBcv_0000384) so that it no longer depends on the obsoleted GO term. Likewise for the subclasses [increased speed of aging](http://purl.obolibrary.org/obo/FBcv_0000792) and [decreased speed of aging](http://purl.obolibrary.org/obo/FBcv_0000791).

There is a proposal to create an ['aging rate' quality in PATO](https://github.com/obophenotype/bio-attribute-ontology/issues/239) that we could use to maintain a logical definition of 'abnormal aging', but until that quality is available and with the FBcv release planned for next week (and with it the refresh of the GO import, which will bring in the obsoletion of GO:0007568), for now we remove the logical definition entirely.

closes #168